### PR TITLE
SKELETON TIMELINE PAGE DONE

### DIFF
--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -1,9 +1,24 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import {
   Box, Container, Typography, Stack, Grid,
 } from '@mui/material';
+import { getExpenses } from '../../api/expenseData';
 
-export default function Month() {
+export default function Month({ obj }) {
+  const [expenses, setExpenses] = useState([]);
+
+  const getMonthlyExpenses = () => {
+    getExpenses(obj.uid).then((response) => setExpenses(response.filter((expenseObj) => expenseObj.month === obj.month)));
+  };
+
+  const monthlyExpensesTotal = expenses.reduce((acc, curr) => acc + curr.amount, 0);
+
+  useEffect(() => {
+    getMonthlyExpenses();
+  }, []);
+
   return (
     <>
       {/* Hero unit */}
@@ -32,7 +47,7 @@ export default function Month() {
             >
               Spending Limit
             </Typography>
-            <div className="money-display" />
+            <div className="money-display"> {obj.earnings} </div>
             <Typography
               component="h1"
               variant="h6"
@@ -42,7 +57,7 @@ export default function Month() {
             >
               Amount Left to Spend:
             </Typography>
-            <div className="money-display"> </div>
+            <div className="money-display"> {obj.earnings - monthlyExpensesTotal} </div>
           </Stack>
           <Stack
             sx={{ pt: 4 }}
@@ -73,3 +88,13 @@ export default function Month() {
     </>
   );
 }
+
+Month.propTypes = {
+  obj: PropTypes.shape({
+    firebaseKey: PropTypes.string,
+    earnings: PropTypes.string,
+    month: PropTypes.string,
+    uid: PropTypes.string,
+    year: PropTypes.string,
+  }).isRequired,
+};

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -5,7 +5,7 @@ import {
 
 export default function Month() {
   return (
-    <main>
+    <>
       {/* Hero unit */}
       <Box
         sx={{
@@ -70,6 +70,6 @@ export default function Month() {
         </Grid>
         <Grid container spacing={4} />
       </Container>
-    </main>
+    </>
   );
 }

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -3,7 +3,7 @@ import {
   Box, Container, Typography, Stack, Grid,
 } from '@mui/material';
 
-export default function Timeline() {
+export default function Month() {
   return (
     <main>
       {/* Hero unit */}

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -11,14 +11,15 @@ export default function Month({ obj }) {
   const [expenses, setExpenses] = useState([]);
 
   const getMonthlyExpenses = () => {
-    getExpenses(obj.uid).then((response) => setExpenses(response.filter((expenseObj) => expenseObj.month === obj.month)));
+    getExpenses(obj.uid).then((res) => setExpenses(res.filter((expense) => expense.month === obj.month)));
   };
 
   const monthlyExpensesTotal = expenses.reduce((acc, curr) => acc + curr.amount, 0);
 
   useEffect(() => {
     getMonthlyExpenses();
-  }, []);
+    console.warn(obj);
+  }, [obj.month]);
 
   return (
     <>
@@ -50,7 +51,7 @@ export default function Month({ obj }) {
             >
               Spending Limit
             </Typography>
-            <div className="money-display"> ${obj.earnings} </div>
+            <div className="money-display"> ${obj.earnings?.toFixed(2)} </div>
             <Typography
               component="h1"
               variant="h6"
@@ -60,7 +61,7 @@ export default function Month({ obj }) {
             >
               Amount Left to Spend:
             </Typography>
-            <div className="money-display"> ${obj.earnings - monthlyExpensesTotal} </div>
+            <div className="money-display"> ${(obj.earnings - monthlyExpensesTotal).toFixed(2)} </div>
           </Stack>
           <Stack
             sx={{ pt: 4 }}

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -50,7 +50,7 @@ export default function Month({ obj }) {
             >
               Spending Limit
             </Typography>
-            <div className="money-display"> {obj.earnings} </div>
+            <div className="money-display"> ${obj.earnings} </div>
             <Typography
               component="h1"
               variant="h6"
@@ -60,7 +60,7 @@ export default function Month({ obj }) {
             >
               Amount Left to Spend:
             </Typography>
-            <div className="money-display"> {obj.earnings - monthlyExpensesTotal} </div>
+            <div className="money-display"> ${obj.earnings - monthlyExpensesTotal} </div>
           </Stack>
           <Stack
             sx={{ pt: 4 }}

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -6,6 +6,8 @@ import {
 } from '@mui/material';
 import { getExpenses } from '../../api/expenseData';
 import ExpenseCard from '../../components/ExpenseCard';
+import MonthlyInome from '../../components/forms/MonthlyInome';
+import Popup from '../../components/Popup';
 
 export default function Month({ obj }) {
   const [expenses, setExpenses] = useState([]);
@@ -15,6 +17,9 @@ export default function Month({ obj }) {
   };
 
   const monthlyExpensesTotal = expenses.reduce((acc, curr) => acc + curr.amount, 0);
+
+  const createMonthlyIncome = <MonthlyInome />;
+  const editMonthlyIncome = <MonthlyInome obj={obj} />;
 
   useEffect(() => {
     getMonthlyExpenses();
@@ -68,7 +73,10 @@ export default function Month({ obj }) {
             direction="row"
             spacing={2}
             justifyContent="center"
-          />
+          >
+            <Popup buttonName="Add Next Month" formTitle="Add a Month" formContent={createMonthlyIncome} />
+            <Popup buttonName="Edit Month" formTitle="Edit a Month" formContent={editMonthlyIncome} />
+          </Stack>
         </Container>
       </Box>
       <Container sx={{ py: 8 }} maxWidth="md">

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -5,6 +5,7 @@ import {
   Box, Container, Typography, Stack, Grid,
 } from '@mui/material';
 import { getExpenses } from '../../api/expenseData';
+import ExpenseCard from '../../components/ExpenseCard';
 
 export default function Month({ obj }) {
   const [expenses, setExpenses] = useState([]);
@@ -36,7 +37,9 @@ export default function Month({ obj }) {
             align="center"
             color="text.primary"
             gutterBottom
-          />
+          >
+            {obj.month}
+          </Typography>
           <Stack spacing={2} direction="column" alignItems="center">
             <Typography
               component="h1"
@@ -83,7 +86,9 @@ export default function Month({ obj }) {
             Expenses
           </Typography>
         </Grid>
-        <Grid container spacing={4} />
+        <Grid container spacing={4}>
+          {expenses.map((expense) => <ExpenseCard expenseObj={expense} onUpdate={getMonthlyExpenses} key={expense.firebaseKey} />)}
+        </Grid>
       </Container>
     </>
   );

--- a/pages/income/Month.js
+++ b/pages/income/Month.js
@@ -56,7 +56,7 @@ export default function Month() {
 
         {/* End hero unit */}
 
-        {/* Start of category unit */}
+        {/* Start of expense unit */}
         <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
           <Typography
             component="h1"

--- a/pages/income/[firebaseKey].js
+++ b/pages/income/[firebaseKey].js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Timeline() {
+  return (
+    <div>timeline</div>
+  );
+}

--- a/pages/income/[firebaseKey].js
+++ b/pages/income/[firebaseKey].js
@@ -1,7 +1,75 @@
 import React from 'react';
+import {
+  Box, Container, Typography, Stack, Grid,
+} from '@mui/material';
 
 export default function Timeline() {
   return (
-    <div>timeline</div>
+    <main>
+      {/* Hero unit */}
+      <Box
+        sx={{
+          bgcolor: 'background.paper',
+          pt: 8,
+          pb: 6,
+        }}
+      >
+        <Container maxWidth="sm">
+          <Typography
+            component="h1"
+            variant="h1"
+            align="center"
+            color="text.primary"
+            gutterBottom
+          />
+          <Stack spacing={2} direction="column" alignItems="center">
+            <Typography
+              component="h1"
+              variant="h6"
+              align="center"
+              color="text.primary"
+              gutterBottom
+            >
+              Spending Limit
+            </Typography>
+            <div className="money-display" />
+            <Typography
+              component="h1"
+              variant="h6"
+              align="center"
+              color="text.primary"
+              gutterBottom
+            >
+              Amount Left to Spend:
+            </Typography>
+            <div className="money-display"> </div>
+          </Stack>
+          <Stack
+            sx={{ pt: 4 }}
+            direction="row"
+            spacing={2}
+            justifyContent="center"
+          />
+        </Container>
+      </Box>
+      <Container sx={{ py: 8 }} maxWidth="md">
+
+        {/* End hero unit */}
+
+        {/* Start of category unit */}
+        <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
+          <Typography
+            component="h1"
+            variant="h2"
+            align="left"
+            color="text.primary"
+            gutterBottom
+          >
+            Expenses
+          </Typography>
+        </Grid>
+        <Grid container spacing={4} />
+      </Container>
+    </main>
   );
 }

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -13,13 +13,11 @@ export default function Timeline() {
     'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec',
   ];
   const [currMonth, setCurrMonth] = useState(currMon);
-  const [selectedMon, setSelectedMon] = useState([]);
+  const [selectedMon, setSelectedMon] = useState(currMonth);
 
   const getSelectedMonthlyIncome = () => {
     getIncome(user.uid).then((res) => setSelectedMon(res.filter((mon) => mon.month.includes(currMonth))));
   };
-
-  console.warn(currMonth, selectedMon);
 
   useEffect(() => {
     getSelectedMonthlyIncome();

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -1,4 +1,4 @@
-import { Stack, Button } from '@mui/material';
+import { Stack, Button, Grid } from '@mui/material';
 import React from 'react';
 
 export default function timeline() {
@@ -9,9 +9,11 @@ export default function timeline() {
 
   return (
     <main>
-      <Stack sx={{ mt: 4 }} spacing={2} direction="row">
-        {monthsArray.map((month) => <Button key={month} variant="contained">{month}</Button>)}
-      </Stack>
+      <Grid align="center">
+        <Stack sx={{ mt: 4 }} spacing={2} direction="row" justifyContent="center">
+          {monthsArray.map((month) => <Button key={month} variant="contained">{month}</Button>)}
+        </Stack>
+      </Grid>
     </main>
   );
 }

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -1,7 +1,15 @@
+import { Stack, Button } from '@mui/material';
 import React from 'react';
 
-export default function Timeline() {
+export default function timeline() {
+  const monthsArray = [
+    'Jan.', 'Feb.', 'Mar.', 'Apr.', 'May', 'June',
+    'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.',
+  ];
+
   return (
-    <div>timeline</div>
+    <Stack sx={{ mt: 4 }} spacing={2} direction="row">
+      {monthsArray.map((month) => <Button variant="outlined">{month}</Button>)}
+    </Stack>
   );
 }

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -8,8 +8,10 @@ export default function timeline() {
   ];
 
   return (
-    <Stack sx={{ mt: 4 }} spacing={2} direction="row">
-      {monthsArray.map((month) => <Button variant="outlined">{month}</Button>)}
-    </Stack>
+    <main>
+      <Stack sx={{ mt: 4 }} spacing={2} direction="row">
+        {monthsArray.map((month) => <Button key={month} variant="contained">{month}</Button>)}
+      </Stack>
+    </main>
   );
 }

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -1,18 +1,30 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Stack, Button, Grid } from '@mui/material';
+import { useAuth } from '../utils/context/authContext';
+import { getIncome } from '../api/incomeData';
 
 export default function Timeline() {
   const date = new Date();
   const currMon = date.toLocaleDateString('default', { month: 'long' });
+  const { user } = useAuth();
 
   const monthsArray = [
     'Jan.', 'Feb.', 'Mar.', 'Apr.', 'May', 'June',
     'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.',
   ];
 
+  const getSelectedMonthlyIncome = () => {
+    getIncome(user.uid).then(console.warn);
+  };
+
   const [currMonth, setCurrMonth] = useState(currMon);
+  // const [selectedMon, setSelectedMon] = useState({});
 
   console.warn(currMonth);
+
+  useEffect(() => {
+    getSelectedMonthlyIncome();
+  });
 
   return (
     <main>

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -1,17 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Stack, Button, Grid } from '@mui/material';
 
-export default function timeline() {
+export default function Timeline() {
+  const date = new Date();
+  const currMon = date.toLocaleDateString('default', { month: 'long' });
+
   const monthsArray = [
     'Jan.', 'Feb.', 'Mar.', 'Apr.', 'May', 'June',
     'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.',
   ];
 
+  const [currMonth, setCurrMonth] = useState(currMon);
+
+  console.warn(currMonth);
+
   return (
     <main>
       <Grid align="center">
         <Stack sx={{ mt: 4 }} spacing={2} direction="row" justifyContent="center">
-          {monthsArray.map((month) => <Button key={month} variant="contained">{month}</Button>)}
+          {monthsArray.map((month) => <Button key={month} variant="contained" onClick={() => setCurrMonth(month)}>{month}</Button>)}
         </Stack>
       </Grid>
     </main>

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -1,5 +1,5 @@
-import { Stack, Button, Grid } from '@mui/material';
 import React from 'react';
+import { Stack, Button, Grid } from '@mui/material';
 
 export default function timeline() {
   const monthsArray = [

--- a/pages/timeline.js
+++ b/pages/timeline.js
@@ -2,25 +2,24 @@ import React, { useEffect, useState } from 'react';
 import { Stack, Button, Grid } from '@mui/material';
 import { useAuth } from '../utils/context/authContext';
 import { getIncome } from '../api/incomeData';
+import Month from './income/Month';
 
 export default function Timeline() {
   const date = new Date();
-  const currMon = date.toLocaleDateString('default', { month: 'long' });
+  const currMon = date.toLocaleDateString('default', { month: 'short' });
   const { user } = useAuth();
-
   const monthsArray = [
-    'Jan.', 'Feb.', 'Mar.', 'Apr.', 'May', 'June',
-    'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.',
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'June',
+    'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec',
   ];
+  const [currMonth, setCurrMonth] = useState(currMon);
+  const [selectedMon, setSelectedMon] = useState([]);
 
   const getSelectedMonthlyIncome = () => {
-    getIncome(user.uid).then(console.warn);
+    getIncome(user.uid).then((res) => setSelectedMon(res.filter((mon) => mon.month.includes(currMonth))));
   };
 
-  const [currMonth, setCurrMonth] = useState(currMon);
-  // const [selectedMon, setSelectedMon] = useState({});
-
-  console.warn(currMonth);
+  console.warn(currMonth, selectedMon);
 
   useEffect(() => {
     getSelectedMonthlyIncome();
@@ -33,6 +32,7 @@ export default function Timeline() {
           {monthsArray.map((month) => <Button key={month} variant="contained" onClick={() => setCurrMonth(month)}>{month}</Button>)}
         </Stack>
       </Grid>
+      <Month obj={selectedMon[0]} />
     </main>
   );
 }


### PR DESCRIPTION
## Description
- Buttons for each month exist at the top.
- Component for the specific monthly page renders with each button selection - expense cards also populate
- Added skeleton buttons for the addition of another month and editing of the current month. Create and edit functionality is still in the works, but read works 

## Related Issue
#14 

## Motivation and Context
This is a necessary addition to the application and encompasses needed functionality.

## How Can This Be Tested?
- Pull PR branch
- Install needed dependencies
- Select the 'Timeline' link at the top of the navbar.
- Navigate to the selected month.
- Ensure that all the expense cards update.

## Screenshots (if appropriate):
N / A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)