### PR TITLE
ROUTING PATCH FOR EXPENSE.JS EDIT CLOSURE

### DIFF
--- a/components/forms/ExpenseForm.js
+++ b/components/forms/ExpenseForm.js
@@ -36,7 +36,7 @@ export default function ExpenseForm({ obj }) {
 
   useEffect(() => {
     if (obj.firebaseKey) setFormInput(obj);
-    console.warn(router.pathname.toString() === '/timeline');
+    console.warn(router.pathname.toString() === '/');
     getCategories(user.uid).then(setCategories);
   }, [obj]);
 
@@ -54,10 +54,10 @@ export default function ExpenseForm({ obj }) {
     // responsible for the conversion of the string-typed input into a float - for use within summation functionality
       formInput.amount = parseFloat(formInput.amount);
       updateExpense(formInput).then(() => getCategoryByName(formInput.category).then(() => {
-        if (router.pathname.toString() === '/') {
-          router.push('/timeline');
-        } else if (router.pathname.toString() === '/timeline') {
+        if (router.pathname.toString() === '/timeline') {
           router.push('/');
+        } else {
+          router.push('/timeline');
         }
       }));
     } else {

--- a/components/forms/ExpenseForm.js
+++ b/components/forms/ExpenseForm.js
@@ -68,11 +68,7 @@ export default function ExpenseForm({ obj }) {
         const patchPayload = { firebaseKey: name };
         updateExpense(patchPayload).then(() => {
           getCategoryByName(formInput.category).then(() => {
-            if (router.pathname === '/') {
-              router.push('/timeline');
-            } else if (router.pathname.toString() === '/timeline') {
-              router.push('/');
-            }
+            router.push('/timeline');
           });
         });
       });

--- a/components/forms/ExpenseForm.js
+++ b/components/forms/ExpenseForm.js
@@ -36,7 +36,7 @@ export default function ExpenseForm({ obj }) {
 
   useEffect(() => {
     if (obj.firebaseKey) setFormInput(obj);
-
+    console.warn(router.pathname.toString() === '/timeline');
     getCategories(user.uid).then(setCategories);
   }, [obj]);
 
@@ -53,7 +53,13 @@ export default function ExpenseForm({ obj }) {
     if (obj.firebaseKey) {
     // responsible for the conversion of the string-typed input into a float - for use within summation functionality
       formInput.amount = parseFloat(formInput.amount);
-      updateExpense(formInput).then(() => getCategoryByName(formInput.category).then(() => router.push('/timeline')));
+      updateExpense(formInput).then(() => getCategoryByName(formInput.category).then(() => {
+        if (router.pathname.toString() === '/') {
+          router.push('/timeline');
+        } else if (router.pathname.toString() === '/timeline') {
+          router.push('/');
+        }
+      }));
     } else {
       // responsible for the conversion of the string-typed input into a float - for use within summation functionality
       formInput.amount = parseFloat(formInput.amount);
@@ -62,7 +68,11 @@ export default function ExpenseForm({ obj }) {
         const patchPayload = { firebaseKey: name };
         updateExpense(patchPayload).then(() => {
           getCategoryByName(formInput.category).then(() => {
-            router.push('/timeline');
+            if (router.pathname === '/') {
+              router.push('/timeline');
+            } else if (router.pathname.toString() === '/timeline') {
+              router.push('/');
+            }
           });
         });
       });


### PR DESCRIPTION
## Description
- Edited ExpenseForm.js 'handleSubmit()' section within the 'edit', (obj.firebaseKey), statement.
- Put in conditional: if the router path is equivalent to the timeline page, route back to the main page. Else, route to the timeline page. Accessed the router object at the .pathname property for the conditional.
- Added this ONLY to the edit section, as expenses can't be added (created) within the timeline page, so routing wouldn't be an issue here. 

## Related Issue
#43 

## Motivation and Context
- While this change doesn't impact functionality, it is a necessary implementation for user experience. Originally, the expense would be reported, but the form wouldn't close/change. However, now, at least the alternate routing gives the illusion of the form closing, while a more permanent fix to the component-popup-form hierarchy is established.

## How Can This Be Tested?
- Pull PR branch
- Install needed dependencies
- Go to 'Timeline' page and select any month with expenses.
- Select on the 'edit' button. 
- Edit any value within the expenses.
- Press 'enter' or 'submit'. 
- You should be routed to a different page.

## Screenshots (if appropriate):
N / A 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
